### PR TITLE
Refactor: Use Pycord's markdown escaping function

### DIFF
--- a/functions/general.py
+++ b/functions/general.py
@@ -29,16 +29,6 @@ def get_latency_ms(bot):
     return round(bot.latency * 1000, 1)
 
 
-def escape_from_md(content: str):
-    if len(content.strip()) == 0:
-        # Only whitespace
-        return content.strip()
-    new_content = content
-    for charset in MARKDOWN_CHARS_TO_ESC.items():
-        new_content = new_content.replace(*charset)
-    logging.info(f"escape_from_md, original={content}, formatted={new_content}")
-    return new_content
-
 def wrap_in_codeblocks(content: str, lang: str = ""):
     if len(content) == 0:
         return content # We cannot have empty content in a codeblock, it will just show ``````

--- a/ui/safeembed.py
+++ b/ui/safeembed.py
@@ -19,12 +19,12 @@ import logging
 from typing import Callable
 
 import discord
+from discord.utils import escape_markdown
 
 from exceptions import FieldTooLongError
-from functions.general import escape_from_md
 
 
-def dummy_escape(content):
+def dummy_escape(content: str) -> str:
     return content
 
 
@@ -42,7 +42,7 @@ class SafeEmbed(discord.Embed):
 
     def safe_append_field(self, field: discord.EmbedField, strip_md: bool = False, error: bool = False,
                           exc_callback: Callable = exc_callback):
-        processor = escape_from_md if strip_md else dummy_escape
+        processor = escape_markdown if strip_md else dummy_escape
 
         name = processor(field.name if field.name is not None else "")
         value = processor(field.value if field.value is not None else "")


### PR DESCRIPTION
Closes #18

## What I did

- [x] Removed the custom implementation of `escape_from_md`
- [x] Passed pycord's `escape_markdown`  function to replace it
- [x] Added type annotations to the dummy escaping function for consistency

Let me know if there's anything else I should take care of on this PR! 